### PR TITLE
Add quality_report validation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ with open('schema.yaml', 'w') as f:
 
 m = Metadata()
 m.update(df, 'schema.yaml', inplace=True)
+m.quality_report(df)
 ```
 
 ### Resultados
@@ -71,6 +72,7 @@ Columns: 2 entries
  1   age                             4   integer
 dtypes: integer(2)
 Validation passed: True
+Quality score: 100.0 (A)
 ```
 
 ## Roadmap

--- a/metadata/core.py
+++ b/metadata/core.py
@@ -632,13 +632,22 @@ class Metadata:
                             model=llm_kwargs.get("model", "gpt-4o-mini"))
 
     def quality_report(self,
+                       df: Optional[pd.DataFrame] = None,
                        *,
                        baseline: Optional[str] = None,
                        weights: Optional[Dict[str, float]] = None,
                        message: bool = True) -> Dict[str, Any]:
+        """Devuelve una puntuación de calidad según los datos validados."""
         self._ensure_loaded()
         weights = weights or {"completeness": .6, "drift": .4}
-        comp_pass = self.validate(pd.DataFrame({}), detail=2, message=False)
+
+        if df is None:
+            df = self._df_cache
+            if df is None:
+                warnings.warn("[quality_report] No DataFrame en caché ni provisto.")
+
+        df_val = df if df is not None else pd.DataFrame({})
+        comp_pass = self.validate(df_val, detail=2, message=False)
         completeness = 1.0 if comp_pass else 0.5
         drift_score  = 1.0
         if baseline:

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import yaml
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from metadata import Metadata
+
+
+def test_quality_report_scores(tmp_path):
+    df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+    schema = {
+        'schema': [
+            {'identity': {'name': 'a'}, 'type': {'logical_type': 'integer'}},
+            {'identity': {'name': 'b'}, 'type': {'logical_type': 'integer'}},
+        ]
+    }
+    path = tmp_path / 'schema.yaml'
+    path.write_text(yaml.safe_dump(schema, sort_keys=False, allow_unicode=True))
+
+    m = Metadata()
+    m.update(df, path, inplace=True)
+
+    report_good = m.quality_report(df, message=False)
+    df_bad = pd.DataFrame({'a': [1, 2]})
+    report_bad = m.quality_report(df_bad, message=False)
+
+    assert report_good['score'] > report_bad['score']


### PR DESCRIPTION
## Summary
- make `Metadata.quality_report` accept an optional DataFrame
- show quality report usage in README example
- test that the quality score depends on input data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889b96a1500832cb5818578b6dfaa26