### PR TITLE
Soporta ZIP remoto en update()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Metadata Toolkit
 
-`metadata` es un paquete de Python para enriquecer y validar esquemas YAML a partir de un `pandas.DataFrame`. Ahora `metadata.update()` permite leer YAML directamente desde URLs, igual que `pandas.read_csv`.
+`metadata` es un paquete de Python para enriquecer y validar esquemas YAML a partir de un `pandas.DataFrame`. Ahora `metadata.update()` permite leer YAML directamente desde URLs, e incluso descargar ZIP remotos con varios esquemas, igual que `pandas.read_csv`.
 
 ## Características
 
@@ -73,10 +73,19 @@ dtypes: integer(2)
 Validation passed: True
 ```
 
+### Ejemplo con ZIP remoto
+
+`metadata.update()` también puede procesar archivos ZIP alojados en la web. Basta con pasar la URL que termine en `.zip`:
+
+```python
+m.update(df, 'https://ejemplo.com/esquemas.zip', verbose=True)
+```
+Esto descargará el ZIP a un directorio temporal, aplicará las actualizaciones y dejará el archivo resultante en la misma carpeta (o en la ruta indicada con `output`).
+
 ## Roadmap
 
 - ✔️ Soporte de YAML remoto (v 2025‑07‑30)
-- ⬜ Descarga de ZIP remotos
+- ✔️ Descarga de ZIP remotos (v 2025‑07‑30)
 - ⬜ Caché local opcional
 - ⬜ CLI (`metadata-cli update titanic.csv titanic.yaml`)
 


### PR DESCRIPTION
## Summary
- descarga ZIP remotos si `meta_source` termina en `.zip`
- maneja `URLError` mostrando un mensaje descriptivo
- indica en README que ya soporta ZIP remoto
- agrega ejemplo de actualización usando un ZIP remoto

## Testing
- `python -m py_compile metadata/core.py`


------
https://chatgpt.com/codex/tasks/task_e_6889b9385f7c832c98e146ab35a303b4