### PR TITLE
Enable JSON metadata files for update

### DIFF
--- a/tests/test_update_json.py
+++ b/tests/test_update_json.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+import pandas as pd
+import yaml
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from metadata import Metadata
+
+
+def test_update_reads_json(tmp_path):
+    df = pd.DataFrame({'a': [1, 2]})
+    schema = {
+        'schema': [
+            {'identity': {'name': 'a'}, 'type': {'logical_type': 'integer'}},
+        ]
+    }
+    path = tmp_path / 'schema.json'
+    path.write_text(json.dumps(schema))
+
+    m = Metadata()
+    m.update(df, path, inplace=True)
+
+    loaded = yaml.safe_load(path.read_text())
+    assert loaded['schema'][0]['statistics']['n_non_null'] == 2


### PR DESCRIPTION
## Summary
- add helper `_read_json` and `_read_meta` to read JSON metadata
- extend `update` to process JSON files (also inside ZIP archives)
- add regression test for JSON input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a3f552214832cab9a6ab41e3767a2