### PR TITLE
Add df upgrade feature and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ m.update(df, 'https://ejemplo.com/esquemas.zip', verbose=True)
 ```
 Esto descargará el ZIP a un directorio temporal, aplicará las actualizaciones y dejará el archivo resultante en la misma carpeta (o en la ruta indicada con `output`).
 
+### Edición de metadatos vía `metadata.df`
+
+Tras `m.update()` el esquema queda en `m.df`, un DataFrame editable. Los cambios
+pueden propagarse al YAML con `m.df.upgrade()`:
+
+```python
+# 1) Si todas las columnas son enteros
+m.df['type.logical_type'] = 'integer'
+
+# 2) Cambiar la descripción de `age`
+m.df.loc['age', 'identity.description_i18n.es'] = 'Edad del pasajero'
+
+# 3) Ajustar el rango permitido de `age`
+m.df.loc['age', ['domain.numeric.min', 'domain.numeric.max']] = [0, 120]
+
+m.df.upgrade('schema.yaml')  # guarda el YAML actualizado
+```
+
 ## Roadmap
 
 - ✔️ Soporte de YAML remoto (v 2025‑07‑30)

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import yaml
+from pathlib import Path
+
+from metadata import Metadata
+
+
+def test_df_upgrade_updates_meta(tmp_path):
+    df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+    schema = {
+        'schema': [
+            {'identity': {'name': 'a'}, 'type': {'logical_type': 'integer'}},
+            {'identity': {'name': 'b'}, 'type': {'logical_type': 'integer'}},
+        ]
+    }
+    yaml_path = tmp_path / 'schema.yaml'
+    yaml_path.write_text(yaml.safe_dump(schema, sort_keys=False, allow_unicode=True))
+
+    m = Metadata()
+    m.update(df, yaml_path, inplace=True, verbose=False)
+    m.df.loc['a', 'type.logical_type'] = 'float'
+    m.df.upgrade()
+
+    assert m._meta['a']['type']['logical_type'] == 'float'


### PR DESCRIPTION
## Summary
- add `_unflatten` & `_from_frame` helpers
- implement `df.upgrade()` to sync edits back to YAML
- update README with examples on editing metadata via `metadata.df`
- test `df.upgrade` functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a413996b8832c9a6bc784affaf9d1