### PR TITLE
Add logging control

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **transform**: devuelve un DataFrame ajustado al esquema.
 - **quality_report**: puntaje sencillo de calidad (completitud + *drift*).
 - **research**: usa OpenAI para explorar relaciones y anomalías.
+- **loglevel**: controla la verbosidad vía `Metadata(loglevel="DEBUG")`.
 
 ## Instalación
 
@@ -52,7 +53,7 @@ import yaml
 with open('schema.yaml', 'w') as f:
     yaml.safe_dump(yaml_schema, f, sort_keys=False, allow_unicode=True)
 
-m = Metadata()
+m = Metadata(loglevel="INFO")
 m.update(df, 'schema.yaml', inplace=True)
 m.quality_report(df)
 ```

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,19 @@
+import logging
+import pandas as pd
+import yaml
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from metadata import Metadata
+
+def test_logger_level(tmp_path):
+    df = pd.DataFrame({'a': [1]})
+    schema = {'schema': [{'identity': {'name': 'a'}, 'type': {'logical_type': 'integer'}}]}
+    path = tmp_path / 's.yaml'
+    path.write_text(yaml.safe_dump(schema, sort_keys=False, allow_unicode=True))
+
+    m = Metadata(loglevel='DEBUG')
+    assert m.logger.level == logging.DEBUG
+    m.update(df, path, inplace=True, verbose=False)
+
+


### PR DESCRIPTION
## Summary
- support configurable logging level via `Metadata(loglevel="INFO")`
- log instead of print across the project
- document loglevel usage in README
- test logging level setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a46324b5c832c8b0c6fe905222005